### PR TITLE
Fix diversity check by excluding loss outcome

### DIFF
--- a/backend/internal/lut/compliance.go
+++ b/backend/internal/lut/compliance.go
@@ -99,7 +99,8 @@ func (c *ComplianceChecker) CheckMode(lut *stakergs.LookupTable) *ComplianceResu
 	// Calculate additional summary values
 	result.Summary.UniquePayouts = c.countUniquePayouts(lut)
 	result.Summary.MaxPayoutHitRate = c.calculateMaxPayoutHitRate(lut, totalWeight)
-	result.Summary.MostFrequentProb = c.calculateMostFrequentProbability(lut, totalWeight)
+	mostFreq, _ = c.calculateMostFrequentProbability(lut, totalWeight)
+	result.Summary.MostFrequentProb = mostFreq
 
 	// Run all checks
 	result.Checks = append(result.Checks, c.checkRTPRange(stats))
@@ -538,7 +539,7 @@ func (c *ComplianceChecker) checkSimulationDiversity(lut *stakergs.LookupTable, 
 	// With 100,000 simulations, a single result shouldn't exceed ~1% probability
 	maxSingleProb := 0.01 // 1%
 
-	mostFreqProb := c.calculateMostFrequentProbability(lut, totalWeight)
+	mostFreqProb, zeroProb := c.calculateMostFrequentProbability(lut, totalWeight)
 
 	check := ComplianceCheck{
 		ID:          CheckSimulationDiversity,
@@ -553,7 +554,7 @@ func (c *ComplianceChecker) checkSimulationDiversity(lut *stakergs.LookupTable, 
 		check.Passed = true
 	} else {
 		check.Passed = false
-		check.Reason = fmt.Sprintf("Most frequent outcome has %.2f%% probability, which may cause repetitive results", mostFreqProb*100)
+		check.Reason = fmt.Sprintf("Most frequent outcome has %.2f%% probability, which may cause repetitive results (info: loss %.2f%%)", mostFreqProb*100, zeroProb*100)
 	}
 
 	return check
@@ -631,24 +632,53 @@ func (c *ComplianceChecker) calculateMaxPayoutHitRate(lut *stakergs.LookupTable,
 	return round4(float64(maxWeight) / float64(totalWeight))
 }
 
-func (c *ComplianceChecker) calculateMostFrequentProbability(lut *stakergs.LookupTable, totalWeight uint64) float64 {
-	// Group by payout and find most frequent
-	payoutWeights := make(map[uint]uint64)
-	for _, o := range lut.Outcomes {
-		payoutWeights[o.Payout] += o.Weight
+func (c *ComplianceChecker) calculateMostFrequentProbability(lut *stakergs.LookupTable, totalWeight uint64) (float64, float64) {
+	if totalWeight == 0 {
+		return 0, 0
 	}
 
-	var maxWeight uint64
-	for _, w := range payoutWeights {
-		if w > maxWeight {
-			maxWeight = w
+	// Aggregate weights per payout while tracking top/second and zero payout weight.
+	payoutWeights := make(map[uint]uint64, len(lut.Outcomes))
+	var topWeight, secondWeight uint64
+	var topPayout uint
+	var zeroWeight uint64
+
+	for _, o := range lut.Outcomes {
+		p := o.Payout
+		w := payoutWeights[p] + o.Weight
+		payoutWeights[p] = w
+
+		if p == 0 {
+			zeroWeight = w
+		}
+
+		if p == topPayout {
+			topWeight = w
+		} else if w > topWeight {
+			secondWeight = topWeight
+			topWeight = w
+			topPayout = p
+		} else if w > secondWeight {
+			secondWeight = w
 		}
 	}
 
-	if totalWeight == 0 {
-		return 0
+	var chosen uint64
+	if topPayout == 0 {
+		chosen = secondWeight
+	} else {
+		chosen = topWeight
 	}
-	return round4(float64(maxWeight) / float64(totalWeight))
+
+	var mostFreqProb, zeroProb float64
+	if chosen > 0 {
+		mostFreqProb = round4(float64(chosen) / float64(totalWeight))
+	}
+	if zeroWeight > 0 {
+		zeroProb = round4(float64(zeroWeight) / float64(totalWeight))
+	}
+
+	return mostFreqProb, zeroProb
 }
 
 func formatLargeNumber(n float64) string {

--- a/backend/internal/lut/compliance.go
+++ b/backend/internal/lut/compliance.go
@@ -99,8 +99,7 @@ func (c *ComplianceChecker) CheckMode(lut *stakergs.LookupTable) *ComplianceResu
 	// Calculate additional summary values
 	result.Summary.UniquePayouts = c.countUniquePayouts(lut)
 	result.Summary.MaxPayoutHitRate = c.calculateMaxPayoutHitRate(lut, totalWeight)
-	mostFreq, _ = c.calculateMostFrequentProbability(lut, totalWeight)
-	result.Summary.MostFrequentProb = mostFreq
+	result.Summary.MostFrequentProb, _ = c.calculateMostFrequentProbability(lut, totalWeight)
 
 	// Run all checks
 	result.Checks = append(result.Checks, c.checkRTPRange(stats))

--- a/backend/internal/optimizer/bucket_optimizer.go
+++ b/backend/internal/optimizer/bucket_optimizer.go
@@ -25,13 +25,13 @@ const (
 
 // BucketConfig defines a payout range and its probability constraint
 type BucketConfig struct {
-	Name        string               `json:"name"`         // Human-readable name (e.g., "small_wins")
-	MinPayout   float64              `json:"min_payout"`   // Minimum payout in range (inclusive)
-	MaxPayout   float64              `json:"max_payout"`   // Maximum payout in range (exclusive, except for last bucket)
-	Type        BucketConstraintType `json:"type"`         // "frequency", "rtp_percent", or "auto"
-	Frequency   float64              `json:"frequency"`    // 1 in N spins (e.g., 20 = 1 in 20 spins)
-	RTPPercent  float64              `json:"rtp_percent"`  // % of total RTP (e.g., 0.5 = 0.5% of RTP)
-	AutoExponent float64             `json:"auto_exponent"` // For auto: weight ∝ 1/payout^exponent (default 1.0, higher = steeper)
+	Name         string               `json:"name"`          // Human-readable name (e.g., "small_wins")
+	MinPayout    float64              `json:"min_payout"`    // Minimum payout in range (inclusive)
+	MaxPayout    float64              `json:"max_payout"`    // Maximum payout in range (exclusive, except for last bucket)
+	Type         BucketConstraintType `json:"type"`          // "frequency", "rtp_percent", or "auto"
+	Frequency    float64              `json:"frequency"`     // 1 in N spins (e.g., 20 = 1 in 20 spins)
+	RTPPercent   float64              `json:"rtp_percent"`   // % of total RTP (e.g., 0.5 = 0.5% of RTP)
+	AutoExponent float64              `json:"auto_exponent"` // For auto: weight ∝ 1/payout^exponent (default 1.0, higher = steeper)
 }
 
 // BucketOptimizerConfig contains full configuration for bucket-based optimization
@@ -95,38 +95,38 @@ type BucketResult struct {
 
 // BucketOptimizerResult contains the full optimization result
 type BucketOptimizerResult struct {
-	OriginalRTP     float64               `json:"original_rtp"`
-	FinalRTP        float64               `json:"final_rtp"`
-	TargetRTP       float64               `json:"target_rtp"`
-	Converged       bool                  `json:"converged"`
-	NewWeights      []uint64              `json:"new_weights"`
-	BucketResults   []BucketResult        `json:"bucket_results"`
-	LossResult      *BucketResult         `json:"loss_result"`
-	TotalWeight     uint64                `json:"total_weight"`
-	Warnings        []string              `json:"warnings,omitempty"`
-	OutcomeDetails  []OutcomeDetail       `json:"outcome_details,omitempty"`
+	OriginalRTP    float64         `json:"original_rtp"`
+	FinalRTP       float64         `json:"final_rtp"`
+	TargetRTP      float64         `json:"target_rtp"`
+	Converged      bool            `json:"converged"`
+	NewWeights     []uint64        `json:"new_weights"`
+	BucketResults  []BucketResult  `json:"bucket_results"`
+	LossResult     *BucketResult   `json:"loss_result"`
+	TotalWeight    uint64          `json:"total_weight"`
+	Warnings       []string        `json:"warnings,omitempty"`
+	OutcomeDetails []OutcomeDetail `json:"outcome_details,omitempty"`
 }
 
 // OutcomeDetail shows how each outcome was assigned
 type OutcomeDetail struct {
-	SimID      int     `json:"sim_id"`
-	Payout     float64 `json:"payout"`
-	OldWeight  uint64  `json:"old_weight"`
-	NewWeight  uint64  `json:"new_weight"`
-	BucketName string  `json:"bucket_name"`
+	SimID       int     `json:"sim_id"`
+	Payout      float64 `json:"payout"`
+	OldWeight   uint64  `json:"old_weight"`
+	NewWeight   uint64  `json:"new_weight"`
+	BucketName  string  `json:"bucket_name"`
 	Probability float64 `json:"probability"`
 }
 
 // bucketAssignment holds outcomes assigned to a bucket during optimization
 type bucketAssignment struct {
-	config            BucketConfig
-	outcomeIndices    []int
-	payouts           []float64
-	targetProb        float64   // Total probability for bucket (sum of outcomeProbs for auto)
-	outcomeProbs      []float64 // Per-outcome probabilities (for auto buckets with varying probs)
-	avgPayout         float64
-	rtpContribution   float64
-	isAuto            bool // True if this is an auto bucket
+	config          BucketConfig
+	outcomeIndices  []int
+	payouts         []float64
+	targetProb      float64   // Total probability for bucket (sum of outcomeProbs for auto)
+	outcomeProbs    []float64 // Per-outcome probabilities (for auto buckets with varying probs)
+	avgPayout       float64
+	rtpContribution float64
+	isAuto          bool // True if this is an auto bucket
 }
 
 // OptimizeTable optimizes a lookup table using bucket constraints
@@ -149,6 +149,24 @@ func (o *BucketOptimizer) OptimizeTable(table *stakergs.LookupTable) (*BucketOpt
 		originalWeights[i] = outcome.Weight
 	}
 
+	// Diagnostics: log max and top 5 normalized payouts to help debug unit mismatches
+	if len(payouts) > 0 {
+		maxP := payouts[0]
+		for _, p := range payouts {
+			if p > maxP {
+				maxP = p
+			}
+		}
+		tmp := make([]float64, len(payouts))
+		copy(tmp, payouts)
+		sort.Slice(tmp, func(i, j int) bool { return tmp[i] > tmp[j] })
+		topN := 5
+		if len(tmp) < topN {
+			topN = len(tmp)
+		}
+		fmt.Printf("[OPTIMIZER] mode=%s cost=%.2f max_normalized=%.2f top%d=%v\n", table.Mode, cost, maxP, topN, tmp[:topN])
+	}
+
 	originalRTP := calculateRTPFromWeights(originalWeights, payouts)
 
 	// Assign outcomes to buckets
@@ -159,7 +177,8 @@ func (o *BucketOptimizer) OptimizeTable(table *stakergs.LookupTable) (*BucketOpt
 	warnings = append(warnings, probWarnings...)
 
 	// Calculate weights
-	newWeights, bucketResults, lossResult := o.calculateWeights(payouts, assignments, lossIndices)
+	newWeights, bucketResults, lossResult, weightWarnings := o.calculateWeights(payouts, assignments, lossIndices)
+	warnings = append(warnings, weightWarnings...)
 
 	// Calculate final RTP
 	finalRTP := calculateRTPFromWeights(newWeights, payouts)
@@ -400,7 +419,7 @@ func (o *BucketOptimizer) calculateTargetProbabilities(assignments []bucketAssig
 }
 
 // calculateWeights converts probabilities to weights
-func (o *BucketOptimizer) calculateWeights(payouts []float64, assignments []bucketAssignment, lossIndices []int) ([]uint64, []BucketResult, *BucketResult) {
+func (o *BucketOptimizer) calculateWeights(payouts []float64, assignments []bucketAssignment, lossIndices []int) ([]uint64, []BucketResult, *BucketResult, []string) {
 	n := len(payouts)
 	weights := make([]uint64, n)
 
@@ -412,9 +431,25 @@ func (o *BucketOptimizer) calculateWeights(payouts []float64, assignments []buck
 	var totalWinRTP float64
 
 	bucketResults := make([]BucketResult, 0, len(assignments))
+	var warnings []string
 
 	for _, bucket := range assignments {
 		if len(bucket.outcomeIndices) == 0 {
+			// Include empty bucket result so UI can show unused buckets
+			bucketResults = append(bucketResults, BucketResult{
+				Name:              bucket.config.Name,
+				MinPayout:         bucket.config.MinPayout,
+				MaxPayout:         bucket.config.MaxPayout,
+				OutcomeCount:      0,
+				TargetProbability: bucket.targetProb,
+				TargetFrequency:   0,
+				ActualProbability: 0,
+				ActualFrequency:   0,
+				RTPContribution:   0,
+				TotalWeight:       0,
+				AvgPayout:         bucket.avgPayout,
+			})
+			warnings = append(warnings, fmt.Sprintf("bucket '%s' has no matching outcomes", bucket.config.Name))
 			continue
 		}
 
@@ -546,13 +581,19 @@ func (o *BucketOptimizer) calculateWeights(payouts []float64, assignments []buck
 	// Update bucket results with actual probabilities and RTP contributions
 	totalWeight := sumUint64(weights)
 	for i := range bucketResults {
-		bucketResults[i].ActualProbability = float64(bucketResults[i].TotalWeight) / float64(totalWeight)
-		bucketResults[i].ActualFrequency = 1.0 / bucketResults[i].ActualProbability
-		// Recalculate RTP contribution based on actual probability
-		bucketResults[i].RTPContribution = bucketResults[i].ActualProbability * bucketResults[i].AvgPayout * 100
+		if bucketResults[i].TotalWeight > 0 && totalWeight > 0 {
+			bucketResults[i].ActualProbability = float64(bucketResults[i].TotalWeight) / float64(totalWeight)
+			bucketResults[i].ActualFrequency = 1.0 / bucketResults[i].ActualProbability
+			// Recalculate RTP contribution based on actual probability
+			bucketResults[i].RTPContribution = bucketResults[i].ActualProbability * bucketResults[i].AvgPayout * 100
+		} else {
+			bucketResults[i].ActualProbability = 0
+			bucketResults[i].ActualFrequency = 0
+			bucketResults[i].RTPContribution = 0
+		}
 	}
 
-	return weights, bucketResults, lossResult
+	return weights, bucketResults, lossResult, warnings
 }
 
 // fineTuneLossWeight adjusts loss weight to hit target RTP precisely
@@ -801,11 +842,11 @@ func suggestBonusBuckets(minPayout, maxPayout, targetRTP float64) []BucketConfig
 		}
 
 		buckets = append(buckets, BucketConfig{
-			Name:         "above_avg",
-			MinPayout:    midHigh,
-			MaxPayout:    highThreshold,
-			Type:         ConstraintRTPPercent,
-			RTPPercent:   15, // 15% of RTP for good outcomes
+			Name:       "above_avg",
+			MinPayout:  midHigh,
+			MaxPayout:  highThreshold,
+			Type:       ConstraintRTPPercent,
+			RTPPercent: 15, // 15% of RTP for good outcomes
 		})
 
 		// Jackpot tier (if exists)

--- a/frontend/src/lib/components/optimizer/BucketConfigPanel.svelte
+++ b/frontend/src/lib/components/optimizer/BucketConfigPanel.svelte
@@ -14,7 +14,7 @@
 	};
 
 	type ShortBucket = [number, number, number, number]; // [min, max, type(0/1/2), value]
-	type ShortConfig = { r: number; b: ShortBucket[] };
+	type ShortConfig = { r: number; f: 'absolute' | 'normalized'; b: ShortBucket[] };
 
 	type BucketResult = {
 		name: string;
@@ -55,6 +55,10 @@
 
 	let targetRtp = $state(0.97);
 	let buckets = $state<BucketConfig[]>([]);
+
+	// Input format: whether the UI fields are absolute multipliers (abs) or normalized (units where 1.0 == mode cost)
+	let inputFormat = $state<'absolute' | 'normalized'>('absolute');
+
 	let isLoading = $state(false);
 	let result = $state<{
 		original_rtp: number;
@@ -87,6 +91,7 @@
 	function toShortConfig(): string {
 		const short: ShortConfig = {
 			r: Math.round(targetRtp * 100),
+			f: inputFormat,
 			b: buckets.map((b) => {
 				const t = TYPE_MAP[b.type];
 				const v = b.type === 'frequency' ? (b.frequency ?? 10) : b.type === 'rtp_percent' ? (b.rtp_percent ?? 1) : (b.auto_exponent ?? 1);
@@ -102,6 +107,9 @@
 			const json = atob(code.trim());
 			const short: ShortConfig = JSON.parse(json);
 			if (!short.r || !Array.isArray(short.b)) return false;
+
+			// Restore input format if present (backwards compatible)
+			inputFormat = (short as any).f ?? 'absolute';
 
 			targetRtp = short.r / 100;
 			buckets = short.b.map(([min, max, t, v], i) => {
@@ -168,6 +176,35 @@
 		}
 		initialized = true;
 	});
+
+	// Convert buckets between absolute and normalized using mode cost
+	function canConvert(): boolean {
+		return !!modeInfo?.cost && modeInfo.cost > 0;
+	}
+
+	function convertBucketsFormat() {
+		if (!canConvert()) {
+			// Try to refresh mode info, then re-check
+			loadModeInfo();
+			if (!canConvert()) {
+				error = 'Mode cost unknown — cannot convert formats';
+				return;
+			}
+		}
+
+		const cost = modeInfo!.cost;
+		if (inputFormat === 'absolute') {
+			// Convert absolute -> normalized (divide by cost)
+			buckets = buckets.map(b => ({ ...b, min_payout: +(b.min_payout / cost), max_payout: +(b.max_payout / cost) }));
+			inputFormat = 'normalized';
+		} else {
+			// Convert normalized -> absolute (multiply by cost)
+			buckets = buckets.map(b => ({ ...b, min_payout: +(b.min_payout * cost), max_payout: +(b.max_payout * cost) }));
+			inputFormat = 'absolute';
+		}
+		// Clear any prior errors
+		error = null;
+	}
 
 	// Reload mode info when mode changes
 	$effect(() => {
@@ -238,14 +275,27 @@
 		result = null;
 
 		try {
-			// Generate names before sending
-			const bucketsWithNames = buckets.map((b, i) => ({ ...b, name: `bucket_${i}` }));
-			const response = await api.bucketOptimize(mode, {
-				target_rtp: targetRtp,
-				buckets: bucketsWithNames,
-				save_to_file: saveToFile,
-				create_backup: createBackup
-			});
+				// Generate names and ensure buckets are normalized for the backend.
+				// Backend expects normalized ranges (units where 1.0 == mode cost).
+				const bucketsWithNames = buckets.map((b, i) => {
+					let min = b.min_payout;
+					let max = b.max_payout;
+					// If user entered absolute values, convert to normalized using mode cost.
+					if (inputFormat === 'absolute' && modeInfo?.cost && modeInfo.cost > 0) {
+						const cost = modeInfo.cost;
+						min = +(min / cost);
+						max = +(max / cost);
+					}
+					// If user selected 'normalized', we trust the inputs and send as-is.
+					return { ...b, name: `bucket_${i}`, min_payout: min, max_payout: max };
+				});
+
+				const response = await api.bucketOptimize(mode, {
+					target_rtp: targetRtp,
+					buckets: bucketsWithNames,
+					save_to_file: saveToFile,
+					create_backup: createBackup
+				});
 			result = response;
 			onOptimize?.(response);
 		} catch (e) {
@@ -306,6 +356,8 @@
 		if (fromShortConfig(config.b64_config)) {
 			selectedProfile = config.profile;
 			showProfiles = false;
+			// Profiles are normalized by default; ensure the UI reflects that
+			inputFormat = 'normalized';
 			error = null;
 		} else {
 			error = 'Failed to apply profile config';
@@ -332,26 +384,61 @@
 </script>
 
 <div class="space-y-4">
-	<!-- Bonus Mode Info Banner -->
-	{#if modeInfo?.is_bonus_mode}
-		<div class="px-4 py-3 rounded-xl bg-violet-500/10 border border-violet-500/30">
-			<div class="flex items-center gap-2 mb-2">
-				<svg class="w-4 h-4 text-violet-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-				</svg>
-				<span class="text-sm font-mono text-violet-400">BONUS MODE</span>
-				<span class="px-2 py-0.5 text-xs font-mono bg-violet-500/20 text-violet-300 rounded">Cost: {modeInfo.cost}x</span>
-			</div>
-			<div class="text-xs font-mono text-violet-200/70 space-y-1">
-				<p>Payouts normalized by cost. Bucket ranges = <span class="text-violet-300">absolute / {modeInfo.cost}</span></p>
-				<div class="flex gap-4 mt-2 text-violet-300/90">
-					<span><span class="text-violet-400">{modeInfo.cost}x</span> abs = <span class="text-emerald-400">1.0x</span> norm</span>
-					<span><span class="text-violet-400">{modeInfo.cost * 5}x</span> abs = <span class="text-emerald-400">5.0x</span> norm</span>
-					<span><span class="text-violet-400">{modeInfo.cost * 100}x</span> abs = <span class="text-emerald-400">100x</span> norm</span>
-				</div>
-			</div>
+	<!-- Bonus Mode / Units Banner -->
+{#if modeInfo?.is_bonus_mode}
+	<div class="px-4 py-3 rounded-xl bg-violet-500/10 border border-violet-500/30">
+		<div class="flex items-center gap-2 mb-2">
+			<svg class="w-4 h-4 text-violet-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+				<path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+			</svg>
+			<span class="text-sm font-mono text-violet-400">BONUS MODE</span>
+			<span class="px-2 py-0.5 text-xs font-mono bg-violet-500/20 text-violet-300 rounded">Cost: {modeInfo.cost}x</span>
+
+			<!-- Input format selector + convert button -->
+			<span class="ml-auto flex items-center gap-2">
+				<span class="text-xs font-mono text-violet-300/80">Bucket ranges:</span>
+				<select
+					bind:value={inputFormat}
+					class="bg-[var(--color-graphite)] border border-white/10 rounded px-2 py-1 text-xs font-mono text-[var(--color-light)] focus:outline-none"
+					aria-label="Bucket range units"
+					title="Choose how you want to type bucket Min/Max values"
+				>
+					<option value="absolute">Absolute (x)</option>
+					<option value="normalized">Normalized (x / cost)</option>
+				</select>
+
+				<button
+					class="p-1 rounded text-xs bg-[var(--color-slate)]/20 text-[var(--color-mist)] hover:bg-[var(--color-slate)]/30 transition-colors"
+					onclick={convertBucketsFormat}
+					title="Convert all current bucket Min/Max values to the other unit using the mode cost"
+					aria-label="Convert bucket values between absolute and normalized"
+				>
+					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M7 7h10M7 7l3 3M7 7l3-3M17 17H7M17 17l-3-3M17 17l-3 3" />
+					</svg>
+				</button>
+			</span>
 		</div>
-	{/if}
+
+		<div class="text-xs font-mono text-violet-200/70 space-y-2">
+			<p>
+				In bonus modes, the optimizer uses <span class="text-violet-300">normalized</span> payouts where
+				<span class="text-emerald-400">1.0x</span> means “one mode cost”.
+				If you select <span class="text-violet-300">Absolute</span> ranges, they are converted automatically before optimizing.
+			</p>
+
+			<div class="space-y-1">
+				<p><span class="text-violet-300">Absolute</span>: type the multipliers exactly as shown in your distribution/payout table (e.g. 500x = 500x).</p>
+				<p><span class="text-violet-300">Normalized</span>: type optimizer units (absolute ÷ cost).</p>
+			</div>
+
+			<p class="text-violet-200/60">
+				The swap button converts the current bucket values to quickly view and edit buckets in the other unit and switches the selected range unit (Absolute ↔ Normalized) so everything stays consistent.
+			</p>
+		</div>
+	</div>
+{/if}
+
 
 	<!-- Header: RTP + Config buttons -->
 	<div class="flex items-center gap-3 p-3 rounded-xl bg-[var(--color-graphite)]/50 border border-white/[0.03]">


### PR DESCRIPTION
### Summary

This PR updates the simulation diversity check to avoid evaluating the loss outcome as part of the "most frequent outcome" diversity threshold.

### Background

The project enforces:
- a hit rate constraint (hit rate must be between 5% and 33%)
- a simulation diversity check, warning when the most frequent outcome exceeds 1%

When the loss outcome is included in the diversity evaluation, the warning becomes effectively unavoidable in valid cases, since:
- loss_rate = 1 - hit_rate
- with hit_rate = 5% -33% -> loss_rate = 67% - 95%

So the loss outcome will naturally dominate frequency distribution.

### Change

- If the most frequent outcome is loss, the diversity check now evaluates the next most frequent non-loss outcome instead.
- The loss outcome is still shown in results, only the diversity threshold evaluation skips it.

### Benefit

This avoids systematic false warnings while preserving the goal of the diversity check: detecting cases where a specific non loss outcome becomes overly dominant.